### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- grant the release workflow contents: write permission so it can create or update releases

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d3ce1248b083259940a1c8812eb72a